### PR TITLE
Ensure python3 compatibility

### DIFF
--- a/interfaces/kaldi_align.py
+++ b/interfaces/kaldi_align.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 
 # Imports


### PR DESCRIPTION
Explicitly uses pyhton3 for kaldi-align.